### PR TITLE
[WIP] Sane action ordering for sync effects

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "all",
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "arrowParens": "avoid"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
         "packages/*"
     ],
     "useWorkspaces": true,
-    "version": "1.2.0"
+    "version": "2.0.0-alpha.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rxsv/core",
-    "version": "1.2.0",
+    "version": "2.0.0-alpha.0",
     "sideEffects": false,
     "description": "RxJS based state management library - core",
     "keywords": [

--- a/packages/core/src/creators/createStore.ts
+++ b/packages/core/src/creators/createStore.ts
@@ -22,7 +22,7 @@ export function createStore<A extends Action, S>(
 
     const state$ = _state$.pipe(source$ =>
         // effects initialization will happen only once
-        // it is triggered by the first subscriber to the `state$` or `action$`
+        // it is triggered by the first subscriber to the `state$`
         concat(source$.pipe(tap(setupEffectsPipeline), take(1), ignoreElements()), source$),
     );
 

--- a/packages/core/src/creators/createStore.ts
+++ b/packages/core/src/creators/createStore.ts
@@ -1,5 +1,5 @@
-import { scan, mergeMap, shareReplay } from 'rxjs/operators';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { scan, mergeMap, shareReplay, tap, take, ignoreElements } from 'rxjs/operators';
+import { BehaviorSubject, Subject, concat, Observable } from 'rxjs';
 
 import { createAction } from './createAction';
 import { Action, Reducer, Store, Effect, witness } from '../types';
@@ -12,7 +12,7 @@ export function createStore<A extends Action, S>(
     const action$ = new BehaviorSubject<A>(createAction('@@INIT') as A);
     const effect$ = new Subject<Effect<A, S>>();
 
-    const state$ = action$.pipe(
+    const _state$ = action$.pipe(
         scan(
             (prevState, action) => rootReducer(prevState, action),
             rootReducer(witness<S>(), createAction('@@INIT/state') as A),
@@ -20,13 +20,11 @@ export function createStore<A extends Action, S>(
         shareReplay(1),
     );
 
-    effect$
-        .pipe(mergeMap(effect => effect(action$, state$)))
-        .subscribe(action => action$.next(action));
-
-    if (rootEffect) {
-        effect$.next(rootEffect);
-    }
+    const state$ = _state$.pipe(source$ =>
+        // effects initialization will happen only once
+        // it is triggered by the first subscriber to the `state$` or `action$`
+        concat(source$.pipe(tap(setupEffectsPipeline), take(1), ignoreElements()), source$),
+    );
 
     const name = storeName ?? 'rxsv';
 
@@ -36,4 +34,14 @@ export function createStore<A extends Action, S>(
         effect$,
         name,
     };
+
+    function setupEffectsPipeline(): void {
+        effect$
+            .pipe(mergeMap(effect => effect(action$, _state$)))
+            .subscribe(action => action$.next(action));
+
+        if (rootEffect) {
+            effect$.next(rootEffect);
+        }
+    }
 }

--- a/packages/core/src/tests/createReducer.test.ts
+++ b/packages/core/src/tests/createReducer.test.ts
@@ -26,7 +26,7 @@ describe('createReducer', () => {
         expect(newState[0]).toBe(payload);
     });
 
-    it('returns previous/defualt state if the provided is undefined', () => {
+    it('returns previous/default state if the provided is undefined', () => {
         const newState = reducer(witness(), Actions.ADD_TODO(payload));
 
         expect(newState[0]).toBeDefined();

--- a/packages/core/src/tests/createStore.test.ts
+++ b/packages/core/src/tests/createStore.test.ts
@@ -98,7 +98,7 @@ describe('createStore', () => {
     });
 
     describe('effects', () => {
-        it('should set up effects pipeline', () => {
+        it('should set up effects pipeline from state$', () => {
             const effectMock = jest.fn(effect);
 
             createStore(reducer, effectMock).state$.subscribe();

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rxsv/demo",
-    "version": "1.2.0",
+    "version": "2.0.0-alpha.0",
     "private": true,
     "description": "dev demo",
     "author": "Grzegorz Bielski <pesiok@gmail.com>",
@@ -30,8 +30,8 @@
         "url": "https://github.com/grzegorz-bielski/rxsv/issues"
     },
     "dependencies": {
-        "@rxsv/core": "^1.2.0",
-        "@rxsv/tools": "^1.2.0",
+        "@rxsv/core": "^2.0.0-alpha.0",
+        "@rxsv/tools": "^2.0.0-alpha.0",
         "clean-webpack-plugin": "^3.0.0",
         "html-webpack-plugin": "^4.0.0",
         "ts-loader": "^6.2.1",

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # `tools`
 
-An utilities package for the `rxsv`.
+A utility package for the `rxsv`.
 
 ```bash
 npm install rxjs @rxsv/core @rxsv/tools
@@ -12,7 +12,7 @@ Connect to the [Redux DevTools](https://github.com/zalmoxisus/redux-devtools-ext
 
 Supported features:
 
--   listening to the `rxsv` actions and displaying current state
+-   listening to the `rxsv` actions and displaying the current state
 -   time travel debugging
 
 ```typescript
@@ -23,7 +23,7 @@ const store = createStore(a => a);
 const enhancedStore = withDevTools(store);
 ```
 
-You can connect multiple `rxsv` store to the devtools, but in such situations you might want to name them.
+You can connect multiple `rxsv` stores to the devtools. They can be distinguished by passing a custom name.
 
 ```typescript
 const store = createStore(reducer, effect, 'ui-widget');

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rxsv/tools",
-    "version": "1.2.0",
+    "version": "2.0.0-alpha.0",
     "description": "rxsv tools",
     "author": "Grzegorz Bielski <pesiok@gmail.com>",
     "homepage": "https://github.com/grzegorz-bielski/rxsv#readme",
@@ -31,7 +31,7 @@
         "url": "https://github.com/grzegorz-bielski/rxsv/issues"
     },
     "dependencies": {
-        "@rxsv/core": "^1.2.0"
+        "@rxsv/core": "^2.0.0-alpha.0"
     },
     "gitHead": "4e6471b494dc2ce97bc729d757e398a8c0b6c2af"
 }


### PR DESCRIPTION
Addresses https://github.com/grzegorz-bielski/rxsv/issues/21

@GrzegorzKazana  I couldn't figure out how to make it work with an `observeOn`,  so instead, I delegated the `effect`s subscription.
 
It means that no `effect` will be run if there aren't any subscribers to the `state$`. This is clearly a breaking change, it might need more tests. 

Available from `npm` at `@rxsv/core@2.0.0-alpha.0`