### PR TITLE
Fix: action order with synchronous effects

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "all",
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "arrowParens": "avoid"
 }

--- a/packages/core/src/creators/createStore.ts
+++ b/packages/core/src/creators/createStore.ts
@@ -1,5 +1,5 @@
-import { scan, mergeMap, shareReplay } from 'rxjs/operators';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { scan, mergeMap, shareReplay, observeOn } from 'rxjs/operators';
+import { asyncScheduler, BehaviorSubject, Subject } from 'rxjs';
 
 import { createAction } from './createAction';
 import { Action, Reducer, Store, Effect, witness } from '../types';
@@ -21,7 +21,10 @@ export function createStore<A extends Action, S>(
     );
 
     effect$
-        .pipe(mergeMap(effect => effect(action$, state$)))
+        .pipe(
+            mergeMap(effect => effect(action$, state$)),
+            observeOn(asyncScheduler),
+        )
         .subscribe(action => action$.next(action));
 
     if (rootEffect) {

--- a/packages/core/src/tests/_utils.ts
+++ b/packages/core/src/tests/_utils.ts
@@ -1,0 +1,9 @@
+export const awaitNMockCalls = (fn: jest.Mock, numberOfCalls: number): Promise<void> =>
+    new Promise(resolve => {
+        const intervalId = setInterval(() => {
+            if (fn.mock.calls.length < numberOfCalls) return;
+
+            clearInterval(intervalId);
+            resolve();
+        }, 50);
+    });


### PR DESCRIPTION
Fixes https://github.com/grzegorz-bielski/rxsv/issues/21

Actions created in effects are `next`ed into the action stream on async tick. This allows actions which triggered the epic to be handled before the newly created one.
